### PR TITLE
refactor: streamline code comments

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,11 @@
-// lib/main.dart
-// This file is now much cleaner and only handles the app's entry point.
-
 import 'package:flutter/material.dart';
-import 'package:flynkle_travel/screens/main_screen.dart'; // Make sure to replace your_app_name with your actual project name
+import 'package:flynkle_travel/screens/main_screen.dart';
 
 void main() {
   runApp(const MyApp());
 }
 
+/// Root widget for the Flynkle Travel application.
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 

--- a/lib/models/destination_model.dart
+++ b/lib/models/destination_model.dart
@@ -1,6 +1,4 @@
-// lib/models/destination_model.dart
-// A simple class to hold our destination data.
-
+/// Model representing a travel destination.
 class Destination {
   final String imageUrl;
   final String city;

--- a/lib/models/travel_plan_model.dart
+++ b/lib/models/travel_plan_model.dart
@@ -1,10 +1,9 @@
-// lib/models/travel_plan_model.dart
-// A class to hold the data for a single travel plan.
-
+/// Model describing a user's travel plan.
 class TravelPlan {
   final String userAvatarUrl;
-  final List<String>
-  countryFlagUrls; // Changed to a list to support multiple flags
+
+  /// URLs for country flags associated with the plan.
+  final List<String> countryFlagUrls;
   final String title;
   final String date;
   final String location;

--- a/lib/screens/chat_page.dart
+++ b/lib/screens/chat_page.dart
@@ -1,10 +1,9 @@
-// lib/screens/chat_page.dart
-// Placeholder for the Chat page.
-
 import 'package:flutter/material.dart';
 
+/// Placeholder screen for chat functionality.
 class ChatPage extends StatelessWidget {
   const ChatPage({super.key});
+
   @override
   Widget build(BuildContext context) {
     return const Scaffold(body: Center(child: Text('Chat Page')));

--- a/lib/screens/events_page.dart
+++ b/lib/screens/events_page.dart
@@ -1,10 +1,9 @@
-// lib/screens/events_page.dart
-// Placeholder for the Events page.
-
 import 'package:flutter/material.dart';
 
+/// Placeholder screen for upcoming events.
 class EventsPage extends StatelessWidget {
   const EventsPage({super.key});
+
   @override
   Widget build(BuildContext context) {
     return const Scaffold(body: Center(child: Text('Events Page')));

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -1,30 +1,26 @@
-// lib/screens/home_page.dart
-// The home page screen, now with the Discounts section.
-
 import 'package:flutter/material.dart';
-import 'package:flynkle_travel/widgets/custom_header.dart'; // Replace with your app name
-import 'package:flynkle_travel/widgets/trending_destinations.dart'; // Replace with your app name
-import 'package:flynkle_travel/widgets/travel_plans_section.dart'; // Replace with your app name
-import 'package:flynkle_travel/widgets/discounts_section.dart'; // Replace with your app name
+import 'package:flynkle_travel/widgets/custom_header.dart';
+import 'package:flynkle_travel/widgets/trending_destinations.dart';
+import 'package:flynkle_travel/widgets/travel_plans_section.dart';
+import 'package:flynkle_travel/widgets/discounts_section.dart';
 
+/// Landing page displaying featured content sections.
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
 
   @override
   Widget build(BuildContext context) {
     return const Scaffold(
-      backgroundColor:
-          Colors.transparent, // Uses the main scaffold's background color
+      backgroundColor: Colors.transparent,
       body: SingleChildScrollView(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             CustomHeader(),
-            SizedBox(height: 10), // A little space after the header
+            SizedBox(height: 10),
             TrendingDestinations(),
             TravelPlansSection(),
             DiscountsSection(),
-            // You can add more sections below here
           ],
         ),
       ),

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -1,6 +1,3 @@
-// lib/screens/main_screen.dart
-// This widget manages the main app structure with the bottom navigation bar.
-
 import 'package:flutter/material.dart';
 import 'package:flynkle_travel/screens/home_page.dart';
 import 'package:flynkle_travel/screens/trips_page.dart';
@@ -16,6 +13,7 @@ class MainScreen extends StatefulWidget {
   State<MainScreen> createState() => _MainScreenState();
 }
 
+/// Holds the main navigation scaffold and bottom navigation bar.
 class _MainScreenState extends State<MainScreen> {
   int _selectedIndex = 0;
 

--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -1,10 +1,9 @@
-// lib/screens/profile_page.dart
-// Placeholder for the Profile page.
-
 import 'package:flutter/material.dart';
 
+/// Placeholder screen for user profile details.
 class ProfilePage extends StatelessWidget {
   const ProfilePage({super.key});
+
   @override
   Widget build(BuildContext context) {
     return const Scaffold(body: Center(child: Text('Profile Page')));

--- a/lib/screens/trips_page.dart
+++ b/lib/screens/trips_page.dart
@@ -1,10 +1,9 @@
-// lib/screens/trips_page.dart
-// Placeholder for the Trips page.
-
 import 'package:flutter/material.dart';
 
+/// Placeholder screen for trip listings.
 class TripsPage extends StatelessWidget {
   const TripsPage({super.key});
+
   @override
   Widget build(BuildContext context) {
     return const Scaffold(body: Center(child: Text('Trips Page')));

--- a/lib/widgets/custom_bottom_nav_bar.dart
+++ b/lib/widgets/custom_bottom_nav_bar.dart
@@ -1,8 +1,6 @@
-// lib/widgets/custom_bottom_nav_bar.dart
-// The custom bottom navigation bar widget.
-
 import 'package:flutter/material.dart';
 
+/// Navigation bar used across the bottom of the app.
 class CustomBottomNavBar extends StatelessWidget {
   final int selectedIndex;
   final Function(int) onItemTapped;

--- a/lib/widgets/custom_header.dart
+++ b/lib/widgets/custom_header.dart
@@ -1,8 +1,6 @@
-// lib/widgets/custom_header.dart
-// The custom header widget.
-
 import 'package:flutter/material.dart';
 
+/// Gradient header with search field and user avatar.
 class CustomHeader extends StatelessWidget {
   const CustomHeader({super.key});
 

--- a/lib/widgets/destination_card.dart
+++ b/lib/widgets/destination_card.dart
@@ -1,9 +1,7 @@
-// lib/widgets/destination_card.dart
-// A reusable card widget to display a single destination.
-
 import 'package:flutter/material.dart';
-import 'package:flynkle_travel/models/destination_model.dart'; // Replace with your app name
+import 'package:flynkle_travel/models/destination_model.dart';
 
+/// Card showing a single travel destination.
 class DestinationCard extends StatelessWidget {
   final Destination destination;
 
@@ -29,7 +27,6 @@ class DestinationCard extends StatelessWidget {
         borderRadius: BorderRadius.circular(20.0),
         child: Stack(
           children: <Widget>[
-            // Background Image
             Positioned.fill(
               child: Image.network(
                 destination.imageUrl,
@@ -61,7 +58,7 @@ class DestinationCard extends StatelessWidget {
                     },
               ),
             ),
-            // Gradient Overlay for better text visibility
+            // Gradient overlay for better text visibility
             Positioned.fill(
               child: Container(
                 decoration: BoxDecoration(
@@ -73,7 +70,6 @@ class DestinationCard extends StatelessWidget {
                 ),
               ),
             ),
-            // City Name
             Positioned(
               top: 15.0,
               left: 15.0,

--- a/lib/widgets/discount_card.dart
+++ b/lib/widgets/discount_card.dart
@@ -1,9 +1,7 @@
-// lib/widgets/discount_card.dart
-// A reusable card widget for the discounts section.
-
 import 'package:flutter/material.dart';
-import 'package:flynkle_travel/models/destination_model.dart'; // Replace with your app name
+import 'package:flynkle_travel/models/destination_model.dart';
 
+/// Card used within the discounts section.
 class DiscountCard extends StatelessWidget {
   final Destination destination;
 
@@ -29,7 +27,6 @@ class DiscountCard extends StatelessWidget {
         borderRadius: BorderRadius.circular(25.0),
         child: Stack(
           children: <Widget>[
-            // Background Image
             Positioned.fill(
               child: Image.network(
                 destination.imageUrl,
@@ -53,7 +50,7 @@ class DiscountCard extends StatelessWidget {
                     },
               ),
             ),
-            // Gradient Overlay for text visibility
+            // Gradient overlay improves text contrast.
             Positioned(
               bottom: 0,
               left: 0,
@@ -69,7 +66,6 @@ class DiscountCard extends StatelessWidget {
                 ),
               ),
             ),
-            // City Name
             Positioned(
               bottom: 20.0,
               left: 20.0,

--- a/lib/widgets/discounts_section.dart
+++ b/lib/widgets/discounts_section.dart
@@ -1,16 +1,14 @@
-// lib/widgets/discounts_section.dart
-// This widget displays the "Fancy a discount?" section.
-
 import 'package:flutter/material.dart';
-import 'package:flynkle_travel/models/destination_model.dart'; // Replace with your app name
-import 'package:flynkle_travel/widgets/discount_card.dart'; // Replace with your app name
+import 'package:flynkle_travel/models/destination_model.dart';
+import 'package:flynkle_travel/widgets/discount_card.dart';
 
+/// Section highlighting discounted destinations.
 class DiscountsSection extends StatelessWidget {
   const DiscountsSection({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // Mock data for discount destinations
+    // Sample destination data for discounts.
     final List<Destination> discountDestinations = [
       Destination(
         imageUrl:
@@ -37,7 +35,6 @@ class DiscountsSection extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        // Section Header
         Padding(
           padding: const EdgeInsets.fromLTRB(20.0, 20.0, 20.0, 10.0),
           child: Column(
@@ -72,7 +69,6 @@ class DiscountsSection extends StatelessWidget {
             ],
           ),
         ),
-        // Horizontal List of Cards
         SizedBox(
           height: 250.0,
           child: ListView.builder(

--- a/lib/widgets/travel_plan_card.dart
+++ b/lib/widgets/travel_plan_card.dart
@@ -1,9 +1,7 @@
-// lib/widgets/travel_plan_card.dart
-// A card to display a single travel plan.
-
 import 'package:flutter/material.dart';
-import 'package:flynkle_travel/models/travel_plan_model.dart'; // Replace with your app name
+import 'package:flynkle_travel/models/travel_plan_model.dart';
 
+/// Card widget displaying details of a travel plan.
 class TravelPlanCard extends StatelessWidget {
   final TravelPlan plan;
 
@@ -30,14 +28,12 @@ class TravelPlanCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Overlapping Avatars
+          // Display user avatar with overlapping country flags.
           SizedBox(
             height: 50,
-            // The Stack's parent needs a defined width to prevent its positioned
-            // children from being clipped.
+            // Parent needs width so positioned children aren't clipped.
             child: Stack(
               children: [
-                // User Avatar is always the first element
                 CircleAvatar(
                   radius: 25,
                   backgroundColor: Colors.grey[200],
@@ -45,11 +41,11 @@ class TravelPlanCard extends StatelessWidget {
                 ),
                 // Generate flag avatars from the list
                 ...List.generate(plan.countryFlagUrls.length, (index) {
-                  // We limit to showing a max of 2-3 flags to avoid overflow
+                  // Limit to two flags to avoid overflow.
                   if (index > 1) return const SizedBox.shrink();
 
                   return Positioned(
-                    // Each flag is pushed further to the right
+                    // Offset each flag to create an overlap effect.
                     left: 35.0 * (index + 1),
                     child: CircleAvatar(
                       radius: 25,
@@ -68,7 +64,6 @@ class TravelPlanCard extends StatelessWidget {
             ),
           ),
           const Spacer(),
-          // Plan Details
           Text(
             plan.title,
             style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
@@ -81,7 +76,6 @@ class TravelPlanCard extends StatelessWidget {
             style: TextStyle(color: Colors.grey[600], fontSize: 14),
           ),
           const Spacer(),
-          // Location Chip
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
             decoration: BoxDecoration(

--- a/lib/widgets/travel_plans_section.dart
+++ b/lib/widgets/travel_plans_section.dart
@@ -1,16 +1,14 @@
-// lib/widgets/travel_plans_section.dart
-// This widget displays the "Travel Plans" section.
-
 import 'package:flutter/material.dart';
-import 'package:flynkle_travel/models/travel_plan_model.dart'; // Replace with your app name
-import 'package:flynkle_travel/widgets/travel_plan_card.dart'; // Replace with your app name
+import 'package:flynkle_travel/models/travel_plan_model.dart';
+import 'package:flynkle_travel/widgets/travel_plan_card.dart';
 
+/// Section displaying a horizontal list of upcoming travel plans.
 class TravelPlansSection extends StatelessWidget {
   const TravelPlansSection({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // Mock data for travel plans, now using a list for flags
+    // Sample travel plan data with country flags.
     final List<TravelPlan> travelPlans = [
       TravelPlan(
         userAvatarUrl:
@@ -26,7 +24,7 @@ class TravelPlansSection extends StatelessWidget {
         countryFlagUrls: [
           'https://flagcdn.com/w320/cz.png',
           'https://flagcdn.com/w320/de.png',
-        ], // This plan now has two flags
+        ],
         title: 'Europe trip',
         date: 'Aug - Sep 2025',
         location: 'Czech Republic',
@@ -45,7 +43,6 @@ class TravelPlansSection extends StatelessWidget {
       padding: const EdgeInsets.symmetric(vertical: 10.0),
       child: Column(
         children: [
-          // Section Header
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 20.0),
             child: Row(
@@ -84,7 +81,6 @@ class TravelPlansSection extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 10),
-          // Horizontal List of Cards
           SizedBox(
             height: 240.0,
             child: ListView.builder(

--- a/lib/widgets/trending_destinations.dart
+++ b/lib/widgets/trending_destinations.dart
@@ -1,16 +1,14 @@
-// lib/widgets/trending_destinations.dart
-// This widget displays the "Trending Destinations" section with a horizontal list.
-
 import 'package:flutter/material.dart';
-import 'package:flynkle_travel/models/destination_model.dart'; // Replace with your app name
-import 'package:flynkle_travel/widgets/destination_card.dart'; // Replace with your app name
+import 'package:flynkle_travel/models/destination_model.dart';
+import 'package:flynkle_travel/widgets/destination_card.dart';
 
+/// Horizontal list showcasing trending destinations.
 class TrendingDestinations extends StatelessWidget {
   const TrendingDestinations({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // Mock data for our destinations
+    // Sample destination data.
     final List<Destination> destinations = [
       Destination(
         imageUrl:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,10 +1,3 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -12,18 +5,14 @@ import 'package:flynkle_travel/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
     await tester.pumpWidget(const MyApp());
 
-    // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);
     expect(find.text('1'), findsNothing);
 
-    // Tap the '+' icon and trigger a frame.
     await tester.tap(find.byIcon(Icons.add));
     await tester.pump();
 
-    // Verify that our counter has incremented.
     expect(find.text('0'), findsNothing);
     expect(find.text('1'), findsOneWidget);
   });


### PR DESCRIPTION
## Summary
- replace redundant file headers with succinct doc comments
- clarify widget logic for overlapping avatars and gradient overlays
- drop placeholder or obvious remarks across screens and tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7191b5d788327a08e0913e3b9bbe5